### PR TITLE
Feature/use launchpad api for all changelog downloads

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: ubuntu-cloud-image-changelog
-version: '0.9.0'
+version: '0.9.1'
 base: core20
 summary: Helpful utility to generate package changelog between two cloud images
 description: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: ubuntu-cloud-image-changelog
-version: '0.9.1'
+version: '0.9.2'
 base: core20
 summary: Helpful utility to generate package changelog between two cloud images
 description: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: ubuntu-cloud-image-changelog
-version: '0.8.1'
+version: '0.9.0'
 base: core20
 summary: Helpful utility to generate package changelog between two cloud images
 description: |

--- a/ubuntu_cloud_image_changelog/README.rst
+++ b/ubuntu_cloud_image_changelog/README.rst
@@ -34,7 +34,7 @@ Usage
 -----
 
 ```
-ubuntu-cloud-image-changelog --from-manifest manifest1.manifest --to-manifest manifest2.manifest
+ubuntu-cloud-image-changelog --from-manifest manifest1.manifest --to-manifest manifest2.manifest --series focal
 ```
 
 If Packages in manifest are known to have been installed from this PPA then you can pass one of more PPAs to ubuntu-cloud-image-changelog for the changelog for those packages to be included in the output.
@@ -43,7 +43,7 @@ If Packages in manifest are known to have been installed from this PPA then you 
 --ppa
 ```
 
-Expected format is 'https://launchpad.net/~%LAUNCHPAD_USERNAME%/+archive/ubuntu/%PPA_NAME%'
+Expected format is '%LAUNCHPAD_USERNAME%/%PPA_NAME%' eg. philroche/cloud-init
 
 Features
 --------

--- a/ubuntu_cloud_image_changelog/setup.cfg
+++ b/ubuntu_cloud_image_changelog/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.1
+current_version = 0.9.0
 commit = True
 tag = True
 

--- a/ubuntu_cloud_image_changelog/setup.cfg
+++ b/ubuntu_cloud_image_changelog/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.9.1
+current_version = 0.9.2
 commit = True
 tag = True
 

--- a/ubuntu_cloud_image_changelog/setup.cfg
+++ b/ubuntu_cloud_image_changelog/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.9.0
+current_version = 0.9.1
 commit = True
 tag = True
 

--- a/ubuntu_cloud_image_changelog/setup.py
+++ b/ubuntu_cloud_image_changelog/setup.py
@@ -43,6 +43,6 @@ setup(
         include=["ubuntu_cloud_image_changelog", "ubuntu_cloud_image_changelog.*"]
     ),
     url="https://github.com/CanonicalLtd/ubuntu_cloud_image_changelog",
-    version="0.9.1",
+    version="0.9.2",
     zip_safe=False,
 )

--- a/ubuntu_cloud_image_changelog/setup.py
+++ b/ubuntu_cloud_image_changelog/setup.py
@@ -10,7 +10,7 @@ with open("README.rst") as readme_file:
 with open("HISTORY.rst") as history_file:
     history = history_file.read()
 
-requirements = ["Click>=7.0", "requests", "python-debian"]
+requirements = ["Click>=7.0", "python-debian", 'launchpadlib']
 
 setup(
     author="Philip Roche",

--- a/ubuntu_cloud_image_changelog/setup.py
+++ b/ubuntu_cloud_image_changelog/setup.py
@@ -43,6 +43,6 @@ setup(
         include=["ubuntu_cloud_image_changelog", "ubuntu_cloud_image_changelog.*"]
     ),
     url="https://github.com/CanonicalLtd/ubuntu_cloud_image_changelog",
-    version="0.9.0",
+    version="0.9.1",
     zip_safe=False,
 )

--- a/ubuntu_cloud_image_changelog/setup.py
+++ b/ubuntu_cloud_image_changelog/setup.py
@@ -43,6 +43,6 @@ setup(
         include=["ubuntu_cloud_image_changelog", "ubuntu_cloud_image_changelog.*"]
     ),
     url="https://github.com/CanonicalLtd/ubuntu_cloud_image_changelog",
-    version="0.8.1",
+    version="0.9.0",
     zip_safe=False,
 )

--- a/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/__init__.py
+++ b/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Philip Roche"""
 __email__ = "phil.roche@canonical.com"
-__version__ = "__version__ = '0.9.1'"
+__version__ = "__version__ = '0.9.2'"

--- a/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/__init__.py
+++ b/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Philip Roche"""
 __email__ = "phil.roche@canonical.com"
-__version__ = "__version__ = '0.9.0'"
+__version__ = "__version__ = '0.9.1'"

--- a/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/__init__.py
+++ b/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Philip Roche"""
 __email__ = "phil.roche@canonical.com"
-__version__ = "__version__ = '0.8.1'"
+__version__ = "__version__ = '0.9.0'"

--- a/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/cli.py
+++ b/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/cli.py
@@ -3,7 +3,7 @@ import os
 import sys
 import tempfile
 import click
-import launchpadagent
+from ubuntu_cloud_image_changelog import launchpadagent
 
 from ubuntu_cloud_image_changelog import lib
 
@@ -180,7 +180,7 @@ def main(
 
         # for each of the deb package diffs and new packages download the
         # changelog
-        with tempfile.TemporaryDirectory() as tmp_cache_directory:
+        with tempfile.TemporaryDirectory(prefix="ubuntu-cloud-image-changelog") as tmp_cache_directory:
             launchpad = launchpadagent.get_launchpad(
                 launchpadlib_dir=tmp_cache_directory,
                 lp_credentials_store=lp_credentials_store,

--- a/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/cli.py
+++ b/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/cli.py
@@ -3,11 +3,22 @@ import os
 import sys
 import tempfile
 import click
+import launchpadagent
 
 from ubuntu_cloud_image_changelog import lib
 
 
 @click.command()
+@click.option(
+    "--lp-credentials-store",
+    envvar="LP_CREDENTIALS_STORE",
+    required=False,
+    help="An optional path to an already configured launchpad credentials store.",
+    default=None,
+)
+@click.option(
+    "--series", help='the Ubuntu series eg. "20.04" or "focal"', required=True
+)
 @click.option(
     "--from-manifest",
     required=True,
@@ -40,11 +51,20 @@ from ubuntu_cloud_image_changelog import lib
     type=click.STRING,
     help="Packages in manifest are known to have been installed from this PPA."
     "Expected format is "
-    "'https://launchpad.net/~%LAUNCHPAD_USERNAME%/+archive/ubuntu/%PPA_NAME%'"
+    "'%LAUNCHPAD_USERNAME%/%PPA_NAME%' eg. philroche/cloud-init"
     "Multiple --ppa options can be specified",
 )
-def main(from_manifest, to_manifest, ppas):
-    # type: (Text, Text, List) -> None
+@click.option(
+    "--image-architecture",
+    help="The architecture of the image to use when querying package "
+    "version in the archive/ppa. The default is amd64",
+    default="amd64",
+    show_default=True,
+)
+def main(
+    lp_credentials_store, series, from_manifest, to_manifest, ppas, image_architecture
+):
+    # type: (Text, Text, Text, Text, List) -> None
     """"""
     from_manifest_lines = from_manifest.readlines()
     to_manifest_lines = to_manifest.readlines()
@@ -69,6 +89,8 @@ def main(from_manifest, to_manifest, ppas):
             package = package.replace(snap_package_prefix, "")
             from_snap_packages[package] = version[1]
         else:
+            # packages ending with ':amd64' or ':arm64' are special
+            package = lib.arch_independent_package_name(package)
             from_deb_packages[package] = version[0]
 
     # parse the to manifest
@@ -78,6 +100,8 @@ def main(from_manifest, to_manifest, ppas):
             package = package.replace(snap_package_prefix, "")
             to_snap_packages[package] = version[1]
         else:
+            # packages ending with ':amd64' or ':arm64' are special
+            package = lib.arch_independent_package_name(package)
             to_deb_packages[package] = version[0]
 
     # Are there any snap package diffs?
@@ -157,29 +181,31 @@ def main(from_manifest, to_manifest, ppas):
         # for each of the deb package diffs and new packages download the
         # changelog
         with tempfile.TemporaryDirectory() as tmp_cache_directory:
+            launchpad = launchpadagent.get_launchpad(
+                launchpadlib_dir=tmp_cache_directory,
+                lp_credentials_store=lp_credentials_store,
+            )
+            ubuntu = launchpad.distributions["ubuntu"]
+            lp_series = ubuntu.getSeries(name_or_version=series)
+            lp_arch_series = lp_series.getDistroArchSeries(archtag=image_architecture)
             for package in added_deb_packages:
-                (
-                    package_changelog_file,
-                    valid_changelog,
-                    valid_ppa_changes,
-                ) = lib.get_changelog(
-                    tmp_cache_directory, package, to_deb_packages[package], ppas
+
+                package_changelog_file = lib.get_changelog(
+                    launchpad,
+                    ubuntu,
+                    lp_series,
+                    lp_arch_series,
+                    tmp_cache_directory,
+                    package,
+                    to_deb_packages[package],
+                    ppas,
                 )
-                if valid_changelog:
-                    # get the most recent changelog entry
-                    version_diff_changelog = lib.parse_changelog(
-                        package_changelog_file, count=1
-                    )
-                elif valid_ppa_changes:
-                    # get the most recent changes entry
-                    version_diff_changelog = lib.parse_ppa_changes(
-                        package_changelog_file
-                    )
-                else:
-                    with open(
-                        package_changelog_file, "rb"
-                    ) as unparsed_invalid_changelog_file:
-                        version_diff_changelog = unparsed_invalid_changelog_file.read()
+
+                # get the most recent changelog entry
+                version_diff_changelog = lib.parse_changelog(
+                    package_changelog_file, count=1
+                )
+
                 click.echo(
                     "==========================================================="
                     "==========================================================="
@@ -193,26 +219,23 @@ def main(from_manifest, to_manifest, ppas):
                 click.echo(version_diff_changelog)
 
             for package, from_to in deb_package_diffs.items():
-                (
-                    package_changelog_file,
-                    valid_changelog,
-                    valid_ppa_changes,
-                ) = lib.get_changelog(tmp_cache_directory, package, from_to["to"], ppas)
-                if valid_changelog:
-                    # get changelog just between the from and to version
-                    version_diff_changelog = lib.parse_changelog(
-                        package_changelog_file, from_to["from"], from_to["to"]
-                    )
-                elif valid_ppa_changes:
-                    # get the most recent changes entry
-                    version_diff_changelog = lib.parse_ppa_changes(
-                        package_changelog_file
-                    )
-                else:
-                    with open(
-                        package_changelog_file, "rb"
-                    ) as unparsed_invalid_changelog_file:
-                        version_diff_changelog = unparsed_invalid_changelog_file.read()
+
+                package_changelog_file = lib.get_changelog(
+                    launchpad,
+                    ubuntu,
+                    lp_series,
+                    lp_arch_series,
+                    tmp_cache_directory,
+                    package,
+                    from_to["to"],
+                    ppas,
+                )
+
+                # get changelog just between the from and to version
+                version_diff_changelog = lib.parse_changelog(
+                    package_changelog_file, from_to["from"], from_to["to"]
+                )
+
                 click.echo(
                     "==========================================================="
                     "==========================================================="

--- a/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/launchpadagent.py
+++ b/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/launchpadagent.py
@@ -1,0 +1,76 @@
+import os
+import sys
+import time
+from launchpadlib.credentials import RequestTokenAuthorizationEngine
+from lazr.restfulclient.errors import HTTPError
+from launchpadlib.launchpad import Launchpad
+from launchpadlib.credentials import UnencryptedFileCredentialStore
+
+ACCESS_TOKEN_POLL_TIME = 1
+WAITING_FOR_USER = """Open this link:
+{}
+to authorize this program to access Launchpad on your behalf.
+Waiting to hear from Launchpad about your decision. . . ."""
+
+
+class AuthorizeRequestTokenWithConsole(RequestTokenAuthorizationEngine):
+    """Authorize a token in a server environment (with no browser).
+
+    Print a link for the user to copy-and-paste into his/her browser
+    for authentication.
+    """
+
+    def __init__(self, *args, **kwargs):
+        # as implemented in AuthorizeRequestTokenWithBrowser
+        kwargs["consumer_name"] = None
+        kwargs.pop("allow_access_levels", None)
+        super(AuthorizeRequestTokenWithConsole, self).__init__(*args, **kwargs)
+
+    def make_end_user_authorize_token(self, credentials, request_token):
+        """Ask the end-user to authorize the token in their browser."""
+        authorization_url = self.authorization_url(request_token)
+        print(WAITING_FOR_USER.format(authorization_url))
+        # if we don't flush we may not see the message
+        sys.stdout.flush()
+        while credentials.access_token is None:
+            time.sleep(ACCESS_TOKEN_POLL_TIME)
+            try:
+                credentials.exchange_request_token_for_access_token(self.web_root)
+                break
+            except HTTPError as e:
+                if e.response.status == 403:
+                    # The user decided not to authorize this
+                    # application.
+                    raise e
+                elif e.response.status == 401:
+                    # The user has not made a decision yet.
+                    pass
+                else:
+                    # There was an error accessing the server.
+                    raise e
+
+
+def get_launchpad(launchpadlib_dir=None, lp_credentials_store=None):
+    """return a launchpad API class. In case launchpadlib_dir is
+    specified used that directory to store launchpadlib cache instead of
+    the default"""
+    if not lp_credentials_store:
+        creds_prefix = os.environ.get("SNAP_USER_COMMON", os.path.expanduser("~"))
+        store = UnencryptedFileCredentialStore(
+            os.path.join(creds_prefix, ".launchpad.credentials")
+        )
+    else:
+        store = UnencryptedFileCredentialStore(lp_credentials_store)
+    lp_app = "ubuntu-cloud-image-changelog"
+    lp_env = "production"
+    lp_version = "devel"
+
+    authorization_engine = AuthorizeRequestTokenWithConsole(lp_env, lp_app)
+    return Launchpad.login_with(
+        lp_app,
+        lp_env,
+        credential_store=store,
+        authorization_engine=authorization_engine,
+        launchpadlib_dir=launchpadlib_dir,
+        version=lp_version,
+    )

--- a/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/lib.py
+++ b/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/lib.py
@@ -1,40 +1,18 @@
 """Main module."""
 import os
 import logging
-import requests
 import subprocess
+import urllib.parse
 from debian import deb822
 from debian.changelog import Changelog
 from debian.debian_support import Version
 
 
-def parse_ppa_changes(ppa_changes_filename):
-    """
-    parse ppa changes file
-    """
-    changelog = ""
-    with open(ppa_changes_filename, "rb") as unparsed_ppa_changes_file:
-        ppa_changes = unparsed_ppa_changes_file.read()
-        change = deb822.Changes(ppa_changes)
-        try:
-            changelog += "{} version {} found in PPA \n\n".format(
-                change.get_as_string("Source"), change.get_as_string("Version")
-            )
-            changelog += "Source: {}\n".format(change.get_as_string("Source"))
-            changelog += "Version: {}\n".format(change.get_as_string("Version"))
-            changelog += "Distribution: {}\n".format(
-                change.get_as_string("Distribution")
-            )
-            changelog += "Urgency: {}\n".format(change.get_as_string("Urgency"))
-            changelog += "Maintainer: {}\n".format(change.get_as_string("Maintainer"))
-            changelog += "Changed-By: {}\n".format(change.get_as_string("Changed-By"))
-            changelog += "Date: {}\n".format(change.get_as_string("Date"))
-            changelog += "Changes:{}\n".format(change.get_as_string("Changes"))
-        except:
-            raise Exception(
-                "Unable to parse PPA changes file {}".format(ppa_changes_filename)
-            )
-    return changelog
+def arch_independent_package_name(package_name):
+    # packages ending with ':amd64' or ':arm64' are special
+    if package_name.endswith(":amd64") or package_name.endswith(":arm64"):
+        package_name = package_name[:-6]
+    return package_name
 
 
 def parse_changelog(changelog_filename, from_version=None, to_version=None, count=1):
@@ -135,70 +113,134 @@ def parse_changelog(changelog_filename, from_version=None, to_version=None, coun
         return changelog
 
 
-def get_changelog(cache_directory, package_name, package_version, ppas):
+def get_changelog(
+    launchpad,
+    ubuntu,
+    lp_series,
+    lp_arch_series,
+    cache_directory,
+    binary_package_name,
+    package_version,
+    ppas,
+):
     """
     Download changelog for source / version and returns path to that
-
-    :param str package_name: Source package name
-    :param str package_version: Source package version
+    :param launchpad: launchpad
+    :param ubuntu: ubuntu
+    :param lp_series: lp_series
+    :param lp_arch_series: lp_arch_series
+    :param str binary_package_name: Binary package name
+    :param str package_version: Package version
     :param list ppas: List of possible ppas package installed from
     :raises Exception: If changelog file could not be downloaded
     :return: changelog file for source package & version
+    :param str image_architecture: Architecture of the image which the manifest belongs to
     :rtype: str
     """
+
+    # packages ending with ':amd64' or ':arm64' are special
+    binary_package_name = arch_independent_package_name(binary_package_name)
+
     cache_filename = "%s/changelog.%s_%s" % (
         cache_directory,
-        package_name,
+        binary_package_name,
         package_version,
     )
 
     if os.path.isfile(cache_filename):
-        logging.debug("Using cached changelog for %s:%s", package_name, package_version)
+        logging.debug(
+            "Using cached changelog for %s:%s", binary_package_name, package_version
+        )
         return cache_filename
 
-    package_prefix = package_name[0:1]
-    # packages starting with 'lib' are special
-    if package_name.startswith("lib"):
-        package_prefix = package_name[0:4]
-
-    # packages ending with ':amd64' are special
-    if package_name.endswith(":amd64"):
-        package_name = package_name[:-6]
-
-    # Changelog URL example http://changelogs.ubuntu.com/changelogs/ \
-    #                           binary/s/sntp/1:4.2.8p12+dfsg-3ubuntu1/
-    changelog_url = (
-        "http://changelogs.ubuntu.com/changelogs/binary/"
-        "{}/{}/{}/changelog".format(package_prefix, package_name, package_version)
-    )
-
-    changelog = requests.get(changelog_url)
-    valid_changelog = False
-    valid_ppa_changes = False
+    package_version_in_archive_changelog = False
+    package_version_in_ppa_changelog = False
     with open(cache_filename, "wb") as cache_file:
-        if changelog.status_code == 200:
-            cache_file.write(changelog.content)
-            valid_changelog = True
-        else:
-            valid_changelog = False
-            # loop through all the specified PPAs and see if a changleog file
-            for ppa in ppas:
-                # Sample changes file URL from a PPA
-                # https://launchpad.net/~cloud-images/+archive/ubuntu/docker1903-k8s/+files/containerd_1.2.10-0ubuntu1~18.04.0.2_source.changes
-                ppa_changes_url = "{}/+files/{}_{}_source.changes".format(
-                    ppa, package_name, package_version
-                )
-                ppa_changes = requests.get(ppa_changes_url)
-                if ppa_changes.status_code == 200:
-                    cache_file.write(ppa_changes.content)
-                    valid_ppa_changes = True
-                    break
+        archive = ubuntu.main_archive
+        binaries = archive.getPublishedBinaries(
+            exact_match=True,
+            binary_name=binary_package_name,
+            distro_arch_series=lp_arch_series,
+            status="Published",
+            order_by_date=True,
+        )
+        if len(binaries):
+            # now get the source package name so we can get the changelog
+            source_package_name = binaries[0].source_package_name
+            sources = archive.getPublishedSources(
+                exact_match=True,
+                source_name=source_package_name,
+                distro_series=lp_series,
+                status="Published",
+                order_by_date=True,
+            )
+            if len(sources):
+                archive_changelog_url = sources[0].changelogUrl()
 
-        if not valid_ppa_changes and not valid_changelog:
+                _patched_archive_changelog_url = launchpad._root_uri.append(
+                    urllib.parse.urlparse(archive_changelog_url).path.lstrip("/")
+                )
+
+                archive_changelog = launchpad._browser.get(
+                    _patched_archive_changelog_url
+                )
+
+                if package_version in archive_changelog.decode("utf-8"):
+                    cache_file.write(archive_changelog)
+                    package_version_in_archive_changelog = True
+
+        if not package_version_in_archive_changelog:
+            # Attempt to get the changelog from any of the passed in PPAs instead
+            for ppa in ppas:
+                ppa_owner, ppa_name = ppa.split("/")
+                archive = launchpad.people[ppa_owner].getPPAByName(name=ppa_name)
+                # using pocket "Release" when using a PPA ...'
+                pocket = "Release"
+                binaries = archive.getPublishedBinaries(
+                    exact_match=True,
+                    binary_name=binary_package_name,
+                    distro_arch_series=lp_arch_series,
+                    status="Published",
+                    pocket=pocket,
+                    order_by_date=True,
+                )
+                if len(binaries):
+                    # now get the source package name so we can get the changelog
+                    source_package_name = binaries[0].source_package_name
+                    sources = archive.getPublishedSources(
+                        exact_match=True,
+                        pocket=pocket,
+                        source_name=source_package_name,
+                        distro_series=lp_series,
+                        status="Published",
+                        order_by_date=True,
+                    )
+                    if len(sources) == 1:
+                        ppa_changelog_url = sources[0].changelogUrl()
+
+                        _patched_ppa_changelog_url = launchpad._root_uri.append(
+                            urllib.parse.urlparse(ppa_changelog_url).path.lstrip("/")
+                        )
+
+                        ppa_changelog = launchpad._browser.get(
+                            _patched_ppa_changelog_url
+                        )
+
+                        if package_version in ppa_changelog.decode("utf-8"):
+                            cache_file.write(ppa_changelog)
+                            package_version_in_ppa_changelog = True
+                            break  # no need to continue iterating the PPA list
+
+        if (
+            not package_version_in_archive_changelog
+            and not package_version_in_ppa_changelog
+        ):
             # can be found for this package and package version
             cache_file.write(
-                "Unable to find changelog or ppa changes file for {} "
-                "version {}.".format(package_name, package_version).encode("utf-8")
+                "Unable to find changelog for {} "
+                "version {}.".format(binary_package_name, package_version).encode(
+                    "utf-8"
+                )
             )
 
-    return cache_filename, valid_changelog, valid_ppa_changes
+    return cache_filename


### PR DESCRIPTION
feat: Migrate to using launchpad API to download changelogs

This removes the need to download from changelogs.ubuntu.com and to
parse PPA source package changes file.

It also means we can download changelogs from private PPAs as long
as the LP user has access to those PPAs.

There is a breaking change to the format that PPAs are passed in.

Now PPA options are '%LAUNCHPAD_USERNAME%/%PPA_NAME%' format eg. philroche/cloud-init
