### PR TITLE
Feature/CVE details json output

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: ubuntu-cloud-image-changelog
-version: '0.10.0'
+version: '0.11.0'
 base: core20
 summary: Helpful utility to generate package changelog between two cloud images
 description: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: ubuntu-cloud-image-changelog
-version: '0.11.0'
+version: '0.12.0'
 base: core20
 summary: Helpful utility to generate package changelog between two cloud images
 description: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,7 +7,7 @@ description: |
   using their package manifests.
 
   Usage:
-  ubuntu-cloud-image-changelog --from-manifest manifest1.manifest --to-manifest manifest2.manifest --series=focal
+  ubuntu-cloud-image-changelog --from-manifest manifest1.manifest --to-manifest manifest2.manifest --from-series=focal --to-series=focal
 
 grade: stable
 confinement: strict

--- a/ubuntu_cloud_image_changelog/README.rst
+++ b/ubuntu_cloud_image_changelog/README.rst
@@ -52,12 +52,6 @@ Expected format is '%LAUNCHPAD_USERNAME%/%PPA_NAME%' eg. philroche/cloud-init
 Highlight the CVEs referenced in each individual changelog entry
 
 ```
---highlight-cves-show-cve-description
-```
-
-When highlighting CVEs, show the CVE description. `--highlight-cves` must also be used for this to take affect.
-
-```
 --output-json changelog.json
 ```
 

--- a/ubuntu_cloud_image_changelog/README.rst
+++ b/ubuntu_cloud_image_changelog/README.rst
@@ -34,7 +34,7 @@ Usage
 -----
 
 ```
-ubuntu-cloud-image-changelog --from-manifest manifest1.manifest --to-manifest manifest2.manifest --series focal
+ubuntu-cloud-image-changelog --from-manifest manifest1.manifest --to-manifest manifest2.manifest --from-series focal --to-series focal
 ```
 
 If Packages in manifest are known to have been installed from this PPA then you can pass one of more PPAs to ubuntu-cloud-image-changelog for the changelog for those packages to be included in the output.
@@ -45,10 +45,36 @@ If Packages in manifest are known to have been installed from this PPA then you 
 
 Expected format is '%LAUNCHPAD_USERNAME%/%PPA_NAME%' eg. philroche/cloud-init
 
-Features
+```
+--highlight-cves
+```
+
+Highlight the CVEs referenced in each individual changelog entry
+
+```
+--highlight-cves-show-cve-description
+```
+
+When highlighting CVEs, show the CVE description. `--highlight-cves` must also be used for this to take affect.
+
+```
+--output-json changelog.json
+```
+
+Output changelog to local `changelog.json` file
+
+```
+--output-json-pretty
+```
+
+Pretty print JSON output with 4 character indentation.  `--output-json` must also be used for this to take affect.
+
+
+TODO
 --------
 
-* TODO
+* There are opportunities to improve performance by parallelizing the source package changelog queries and parsing.
+
 
 Credits
 -------

--- a/ubuntu_cloud_image_changelog/requirements_dev.txt
+++ b/ubuntu_cloud_image_changelog/requirements_dev.txt
@@ -1,3 +1,4 @@
+black
 pip
 bump2version
 wheel

--- a/ubuntu_cloud_image_changelog/setup.cfg
+++ b/ubuntu_cloud_image_changelog/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.11.0
+current_version = 0.12.0
 commit = True
 tag = True
 

--- a/ubuntu_cloud_image_changelog/setup.cfg
+++ b/ubuntu_cloud_image_changelog/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.10.0
+current_version = 0.11.0
 commit = True
 tag = True
 

--- a/ubuntu_cloud_image_changelog/setup.py
+++ b/ubuntu_cloud_image_changelog/setup.py
@@ -43,6 +43,6 @@ setup(
         include=["ubuntu_cloud_image_changelog", "ubuntu_cloud_image_changelog.*"]
     ),
     url="https://github.com/CanonicalLtd/ubuntu_cloud_image_changelog",
-    version="0.10.0",
+    version="0.11.0",
     zip_safe=False,
 )

--- a/ubuntu_cloud_image_changelog/setup.py
+++ b/ubuntu_cloud_image_changelog/setup.py
@@ -10,7 +10,7 @@ with open("README.rst") as readme_file:
 with open("HISTORY.rst") as history_file:
     history = history_file.read()
 
-requirements = ["Click>=7.0", "python-debian", 'launchpadlib']
+requirements = ["Click>=7.0", "colorama", "python-debian", 'launchpadlib']
 
 setup(
     author="Philip Roche",

--- a/ubuntu_cloud_image_changelog/setup.py
+++ b/ubuntu_cloud_image_changelog/setup.py
@@ -43,6 +43,6 @@ setup(
         include=["ubuntu_cloud_image_changelog", "ubuntu_cloud_image_changelog.*"]
     ),
     url="https://github.com/CanonicalLtd/ubuntu_cloud_image_changelog",
-    version="0.11.0",
+    version="0.12.0",
     zip_safe=False,
 )

--- a/ubuntu_cloud_image_changelog/setup.py
+++ b/ubuntu_cloud_image_changelog/setup.py
@@ -10,7 +10,7 @@ with open("README.rst") as readme_file:
 with open("HISTORY.rst") as history_file:
     history = history_file.read()
 
-requirements = ["Click>=7.0", "colorama", "python-debian", 'launchpadlib']
+requirements = ["Click>=7.0", "colorama", "python-debian", "launchpadlib"]
 
 setup(
     author="Philip Roche",

--- a/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/__init__.py
+++ b/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Philip Roche"""
 __email__ = "phil.roche@canonical.com"
-__version__ = "0.11.0"
+__version__ = "0.12.0"

--- a/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/__init__.py
+++ b/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Philip Roche"""
 __email__ = "phil.roche@canonical.com"
-__version__ = "0.10.0"
+__version__ = "0.11.0"

--- a/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/cli.py
+++ b/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/cli.py
@@ -73,13 +73,6 @@ from ubuntu_cloud_image_changelog import lib
     default=False,
 )
 @click.option(
-    "--highlight-cves-show-cve-description",
-    help="When highlighting CVEs, show the CVE description. "
-    "`--highlight-cves` must also be used for this to take affect.",
-    is_flag=True,
-    default=False,
-)
-@click.option(
     "--output-json",
     help="Output the changelog in JSON format to the specified file",
     type=click.Path(exists=False, dir_okay=False, writable=True),
@@ -101,7 +94,6 @@ def main(
     ppas,
     image_architecture,
     highlight_cves,
-    highlight_cves_show_cve_description,
     output_json,
     output_json_pretty,
 ):
@@ -357,9 +349,7 @@ def main(
                                     fg=cve_priority_color,
                                     bold=cve_priority_bold,
                                 ),
-                                ": {}".format(cve_referenced["cve_description"])
-                                if highlight_cves_show_cve_description
-                                else "",
+                                ": {}".format(cve_referenced["cve_description"]),
                             )
                         )
                         changelog["added"]["deb"][package]["cves"].append(
@@ -468,9 +458,7 @@ def main(
                                     fg=cve_priority_color,
                                     bold=cve_priority_bold,
                                 ),
-                                ": {}".format(cve_referenced["cve_description"])
-                                if highlight_cves_show_cve_description
-                                else "",
+                                ": {}".format(cve_referenced["cve_description"]),
                             )
                         )
                         changelog["diff"]["deb"][package]["cves"].append(cve_referenced)

--- a/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/cli.py
+++ b/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/cli.py
@@ -66,28 +66,36 @@ from ubuntu_cloud_image_changelog import lib
     show_default=True,
 )
 @click.option(
-    '--highlight-cves',
-    help='Highlight the CVEs referenced in each individual changelog entry'
-         '. Default: %(default)s',
-    is_flag=True, default=False)
+    "--highlight-cves",
+    help="Highlight the CVEs referenced in each individual changelog entry"
+    ". Default: %(default)s",
+    is_flag=True,
+    default=False,
+)
 @click.option(
-    '--highlight-cves-show-cve-description',
-    help='When highlighting CVEs, show the CVE description. '
-         '`--highlight-cves` must also be used for this to take affect.',
-    is_flag=True, default=False)
+    "--highlight-cves-show-cve-description",
+    help="When highlighting CVEs, show the CVE description. "
+    "`--highlight-cves` must also be used for this to take affect.",
+    is_flag=True,
+    default=False,
+)
 @click.option(
-    '--output-json',
-    help='Output the changelog in JSON format to the specified file',
+    "--output-json",
+    help="Output the changelog in JSON format to the specified file",
     type=click.Path(exists=False, dir_okay=False, writable=True),
-    default=None)
+    default=None,
+)
 @click.option(
-    '--output-json-pretty',
-    help='Output the JSON changelog in a human readable format. '
-         'This option is ignored if `--output-json` is not specified.',
-    is_flag=True, default=False)
+    "--output-json-pretty",
+    help="Output the JSON changelog in a human readable format. "
+    "This option is ignored if `--output-json` is not specified.",
+    is_flag=True,
+    default=False,
+)
 def main(
     lp_credentials_store,
-    from_series, to_series,
+    from_series,
+    to_series,
     from_manifest,
     to_manifest,
     ppas,
@@ -116,11 +124,12 @@ def main(
     snap_package_diffs = {}
 
     # Store all changleog items in a dict so we can output in different formats and not just txt.
-    changelog = {"summary": {},
-                 "diff": {"deb": {}, "snap": {}},
-                 "added": {"deb": {}, "snap": {}},
-                 "removed": {"deb": {}, "snap": {}}
-                 }
+    changelog = {
+        "summary": {},
+        "diff": {"deb": {}, "snap": {}},
+        "added": {"deb": {}, "snap": {}},
+        "removed": {"deb": {}, "snap": {}},
+    }
     # parse the from manifest
     for from_manifest_line in from_manifest_lines:
         package, *version = from_manifest_line.decode("utf-8").strip().split("\t")
@@ -149,7 +158,10 @@ def main(
         for package, version in from_snap_packages.items():
             if package not in to_snap_packages.keys():
                 removed_snap_packages.append(package)
-                changelog["removed"]["snap"][package] = {"from": {"version": version}, "to": {"version": None}}
+                changelog["removed"]["snap"][package] = {
+                    "from": {"version": version},
+                    "to": {"version": None},
+                }
 
         for package, version in to_snap_packages.items():
             if package not in from_snap_packages.keys():
@@ -164,9 +176,11 @@ def main(
                         "from": from_package_version,
                         "to": to_package_version,
                     }
-        changelog["summary"]["snap"] = {"added": added_snap_packages,
-                                        "removed": removed_snap_packages,
-                                        "diff": list(snap_package_diffs.keys())}
+        changelog["summary"]["snap"] = {
+            "added": added_snap_packages,
+            "removed": removed_snap_packages,
+            "diff": list(snap_package_diffs.keys()),
+        }
         click.echo("Snap packages added: {}".format(added_snap_packages))
         click.echo("Snap packages removed: {}".format(removed_snap_packages))
         click.echo("Snap packages changed: {}".format(list(snap_package_diffs.keys())))
@@ -177,12 +191,18 @@ def main(
         for package, version in from_deb_packages.items():
             if package not in to_deb_packages.keys():
                 removed_deb_packages.append(package)
-                changelog["removed"]["deb"][package] = {"from": {"version": version}, "to": {"version": None}}
+                changelog["removed"]["deb"][package] = {
+                    "from": {"version": version},
+                    "to": {"version": None},
+                }
 
         for package, version in to_deb_packages.items():
             if package not in from_deb_packages.keys():
                 added_deb_packages.append(package)
-                changelog["added"]["deb"][package] = {"from": {"version": None}, "to": {"version": version}}
+                changelog["added"]["deb"][package] = {
+                    "from": {"version": None},
+                    "to": {"version": version},
+                }
 
         for to_package, to_package_version in to_deb_packages.items():
             # only need to find diff for packages that are not new
@@ -193,9 +213,11 @@ def main(
                         "from": from_package_version,
                         "to": to_package_version,
                     }
-        changelog["summary"]["deb"] = {"added": added_deb_packages,
-                                       "removed": removed_deb_packages,
-                                       "diff": list(deb_package_diffs.keys())}
+        changelog["summary"]["deb"] = {
+            "added": added_deb_packages,
+            "removed": removed_deb_packages,
+            "diff": list(deb_package_diffs.keys()),
+        }
         click.echo("Deb packages added: {}".format(added_deb_packages))
         click.echo("Deb packages removed: {}".format(removed_deb_packages))
         click.echo("Deb packages changed: {}".format(list(deb_package_diffs.keys())))
@@ -219,7 +241,10 @@ def main(
                 )
             )
 
-            changelog["diff"]["snap"][package] = {"from": from_to["from"], "to": from_to["to"]}
+            changelog["diff"]["snap"][package] = {
+                "from": from_to["from"],
+                "to": from_to["to"],
+            }
 
             click.echo()
 
@@ -239,11 +264,24 @@ def main(
             ubuntu = launchpad.distributions["ubuntu"]
             to_lp_series = ubuntu.getSeries(name_or_version=to_series)
             from_lp_series = ubuntu.getSeries(name_or_version=from_series)
-            to_lp_arch_series = to_lp_series.getDistroArchSeries(archtag=image_architecture)
-            from_lp_arch_series = from_lp_series.getDistroArchSeries(archtag=image_architecture)
+            to_lp_arch_series = to_lp_series.getDistroArchSeries(
+                archtag=image_architecture
+            )
+            from_lp_arch_series = from_lp_series.getDistroArchSeries(
+                archtag=image_architecture
+            )
             for package in added_deb_packages:
-                to_source_package_name, to_source_package_version = lib.get_source_package_details(
-                    ubuntu, launchpad, to_lp_arch_series, package, to_deb_packages[package], ppas)
+                (
+                    to_source_package_name,
+                    to_source_package_version,
+                ) = lib.get_source_package_details(
+                    ubuntu,
+                    launchpad,
+                    to_lp_arch_series,
+                    package,
+                    to_deb_packages[package],
+                    ppas,
+                )
                 package_changelog_file = lib.get_changelog(
                     launchpad,
                     ubuntu,
@@ -255,12 +293,16 @@ def main(
                 )
 
                 # get the three most recent changelog entries
-                version_diff_changelog, cves_referenced, version_diff_changelogs = lib.parse_changelog(
+                (
+                    version_diff_changelog,
+                    cves_referenced,
+                    version_diff_changelogs,
+                ) = lib.parse_changelog(
                     launchpad,
                     package_changelog_file,
                     to_version=to_source_package_version,
                     count=3,
-                    highlight_cves=highlight_cves
+                    highlight_cves=highlight_cves,
                 )
 
                 click.echo(
@@ -269,7 +311,10 @@ def main(
                 )
                 click.echo(
                     "{} version '{}' (source package {} version '{}') was added. Below are the three most recent changelog entries".format(
-                        package, to_deb_packages[package], to_source_package_name, to_source_package_version
+                        package,
+                        to_deb_packages[package],
+                        to_source_package_name,
+                        to_source_package_version,
                     )
                 )
                 changelog["added"]["deb"][package] = {
@@ -283,7 +328,9 @@ def main(
                         "source_package_version": to_source_package_version,
                         "version": to_deb_packages[package],
                     },
-                    "notes": ["For a newly added package only the three most recent changelog entries are shown."],
+                    "notes": [
+                        "For a newly added package only the three most recent changelog entries are shown."
+                    ],
                     "cves": [],
                     "changes": [],
                 }
@@ -293,27 +340,57 @@ def main(
                     for cve_referenced in cves_referenced:
                         cve_priority_color = None
                         cve_priority_bold = False
-                        if cve_referenced['cve_priority'] == 'high' or cve_referenced['cve_priority'] == 'critical':
-                            cve_priority_color = 'red'
+                        if (
+                            cve_referenced["cve_priority"] == "high"
+                            or cve_referenced["cve_priority"] == "critical"
+                        ):
+                            cve_priority_color = "red"
                             cve_priority_bold = True
-                        elif cve_referenced['cve_priority'] == 'medium':
-                            cve_priority_color = 'yellow'
+                        elif cve_referenced["cve_priority"] == "medium":
+                            cve_priority_color = "yellow"
                             cve_priority_bold = True
-                        click.echo('\t- {} ({} priority){}'.format(cve_referenced['cve'], click.style(cve_referenced['cve_priority'], fg=cve_priority_color, bold=cve_priority_bold),
-                                                                   ': {}'.format(cve_referenced[
-                                                                                     'cve_description'])
-                                                                   if highlight_cves_show_cve_description else ''
-                                                                   ))
-                        changelog["added"]["deb"][package]["cves"].append(cve_referenced)
+                        click.echo(
+                            "\t- {} ({} priority){}".format(
+                                cve_referenced["cve"],
+                                click.style(
+                                    cve_referenced["cve_priority"],
+                                    fg=cve_priority_color,
+                                    bold=cve_priority_bold,
+                                ),
+                                ": {}".format(cve_referenced["cve_description"])
+                                if highlight_cves_show_cve_description
+                                else "",
+                            )
+                        )
+                        changelog["added"]["deb"][package]["cves"].append(
+                            cve_referenced
+                        )
                     click.echo()
                 for version_diff_changelogs_entry in version_diff_changelogs:
-                    changelog["added"]["deb"][package]["changes"].append(version_diff_changelogs_entry)
+                    changelog["added"]["deb"][package]["changes"].append(
+                        version_diff_changelogs_entry
+                    )
                 click.echo(version_diff_changelog)
 
             for package, from_to in deb_package_diffs.items():
 
-                from_source_package_name, from_source_package_version = lib.get_source_package_details(ubuntu, launchpad, from_lp_arch_series, package, from_to["from"], ppas)
-                to_source_package_name, to_source_package_version = lib.get_source_package_details(ubuntu, launchpad, to_lp_arch_series, package, from_to["to"], ppas)
+                (
+                    from_source_package_name,
+                    from_source_package_version,
+                ) = lib.get_source_package_details(
+                    ubuntu,
+                    launchpad,
+                    from_lp_arch_series,
+                    package,
+                    from_to["from"],
+                    ppas,
+                )
+                (
+                    to_source_package_name,
+                    to_source_package_version,
+                ) = lib.get_source_package_details(
+                    ubuntu, launchpad, to_lp_arch_series, package, from_to["to"], ppas
+                )
 
                 package_changelog_file = lib.get_changelog(
                     launchpad,
@@ -325,15 +402,18 @@ def main(
                     ppas,
                 )
 
-
                 # get changelog just between the from and to version
-                version_diff_changelog, cves_referenced, version_diff_changelogs = lib.parse_changelog(
+                (
+                    version_diff_changelog,
+                    cves_referenced,
+                    version_diff_changelogs,
+                ) = lib.parse_changelog(
                     launchpad,
                     package_changelog_file,
                     from_version=from_source_package_version,
                     to_version=to_source_package_version,
                     count=None,
-                    highlight_cves=highlight_cves
+                    highlight_cves=highlight_cves,
                 )
 
                 click.echo(
@@ -342,7 +422,9 @@ def main(
                 )
                 click.echo(
                     "{} changed from version '{}' to version '{}' (source package changed from {} version '{}' to {} version '{}')".format(
-                        package, from_to["from"], from_to["to"],
+                        package,
+                        from_to["from"],
+                        from_to["to"],
                         from_source_package_name,
                         from_source_package_version,
                         to_source_package_name,
@@ -369,24 +451,37 @@ def main(
                     for cve_referenced in cves_referenced:
                         cve_priority_color = None
                         cve_priority_bold = False
-                        if cve_referenced['cve_priority'] == 'high' or cve_referenced['cve_priority'] == 'critical':
-                            cve_priority_color = 'red'
+                        if (
+                            cve_referenced["cve_priority"] == "high"
+                            or cve_referenced["cve_priority"] == "critical"
+                        ):
+                            cve_priority_color = "red"
                             cve_priority_bold = True
-                        elif cve_referenced['cve_priority'] == 'medium':
-                            cve_priority_color = 'yellow'
+                        elif cve_referenced["cve_priority"] == "medium":
+                            cve_priority_color = "yellow"
                             cve_priority_bold = True
-                        click.echo('\t- {} ({} priority){}'.format(cve_referenced['cve'], click.style(cve_referenced['cve_priority'], fg=cve_priority_color, bold=cve_priority_bold),
-                                                                   ': {}'.format(cve_referenced[
-                                                                                     'cve_description'])
-                                                                   if highlight_cves_show_cve_description else ''
-                                                                   ))
+                        click.echo(
+                            "\t- {} ({} priority){}".format(
+                                cve_referenced["cve"],
+                                click.style(
+                                    cve_referenced["cve_priority"],
+                                    fg=cve_priority_color,
+                                    bold=cve_priority_bold,
+                                ),
+                                ": {}".format(cve_referenced["cve_description"])
+                                if highlight_cves_show_cve_description
+                                else "",
+                            )
+                        )
                         changelog["diff"]["deb"][package]["cves"].append(cve_referenced)
                     click.echo()
                 for version_diff_changelogs_entry in version_diff_changelogs:
-                    changelog["diff"]["deb"][package]["changes"].append(version_diff_changelogs_entry)
+                    changelog["diff"]["deb"][package]["changes"].append(
+                        version_diff_changelogs_entry
+                    )
                 click.echo(version_diff_changelog)
     if output_json:
-        with open(output_json, 'w') as ouput_json_file:
+        with open(output_json, "w") as ouput_json_file:
             if output_json_pretty:
                 json.dump(changelog, ouput_json_file, indent=4)
             else:

--- a/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/cli.py
+++ b/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/cli.py
@@ -3,6 +3,7 @@ import os
 import sys
 import tempfile
 import click
+import json
 from ubuntu_cloud_image_changelog import launchpadagent
 
 from ubuntu_cloud_image_changelog import lib
@@ -64,10 +65,39 @@ from ubuntu_cloud_image_changelog import lib
     default="amd64",
     show_default=True,
 )
+@click.option(
+    '--highlight-cves',
+    help='Highlight the CVEs referenced in each individual changelog entry'
+         '. Default: %(default)s',
+    is_flag=True, default=False)
+@click.option(
+    '--highlight-cves-show-cve-description',
+    help='When highlighting CVEs, show the CVE description. '
+         '`--highlight-cves` must also be used for this to take affect.',
+    is_flag=True, default=False)
+@click.option(
+    '--output-json',
+    help='Output the changelog in JSON format to the specified file',
+    type=click.Path(exists=False, dir_okay=False, writable=True),
+    default=None)
+@click.option(
+    '--output-json-pretty',
+    help='Output the JSON changelog in a human readable format. '
+         'This option is ignored if `--output-json` is not specified.',
+    is_flag=True, default=False)
 def main(
-    lp_credentials_store, from_series, to_series, from_manifest, to_manifest, ppas, image_architecture
+    lp_credentials_store,
+    from_series, to_series,
+    from_manifest,
+    to_manifest,
+    ppas,
+    image_architecture,
+    highlight_cves,
+    highlight_cves_show_cve_description,
+    output_json,
+    output_json_pretty,
 ):
-    # type: (Text, Text, Text, Text, Text, List) -> None
+    # type: (Text, Text, Text, Text, Text, List, bool, bool, Text, bool) -> None
     """"""
     from_manifest_lines = from_manifest.readlines()
     to_manifest_lines = to_manifest.readlines()
@@ -85,6 +115,12 @@ def main(
     added_snap_packages = []
     snap_package_diffs = {}
 
+    # Store all changleog items in a dict so we can output in different formats and not just txt.
+    changelog = {"summary": {},
+                 "diff": {"deb": {}, "snap": {}},
+                 "added": {"deb": {}, "snap": {}},
+                 "removed": {"deb": {}, "snap": {}}
+                 }
     # parse the from manifest
     for from_manifest_line in from_manifest_lines:
         package, *version = from_manifest_line.decode("utf-8").strip().split("\t")
@@ -110,11 +146,12 @@ def main(
     # Are there any snap package diffs?
     if from_snap_packages or to_snap_packages:
 
-        for package in from_snap_packages.keys():
+        for package, version in from_snap_packages.items():
             if package not in to_snap_packages.keys():
                 removed_snap_packages.append(package)
+                changelog["removed"]["snap"][package] = {"from": {"version": version}, "to": {"version": None}}
 
-        for package in to_snap_packages.keys():
+        for package, version in to_snap_packages.items():
             if package not in from_snap_packages.keys():
                 added_snap_packages.append(package)
 
@@ -127,7 +164,9 @@ def main(
                         "from": from_package_version,
                         "to": to_package_version,
                     }
-
+        changelog["summary"]["snap"] = {"added": added_snap_packages,
+                                        "removed": removed_snap_packages,
+                                        "diff": list(snap_package_diffs.keys())}
         click.echo("Snap packages added: {}".format(added_snap_packages))
         click.echo("Snap packages removed: {}".format(removed_snap_packages))
         click.echo("Snap packages changed: {}".format(list(snap_package_diffs.keys())))
@@ -135,13 +174,15 @@ def main(
     # Are there any deb package diffs?
     if from_deb_packages or to_deb_packages:
 
-        for package in from_deb_packages.keys():
+        for package, version in from_deb_packages.items():
             if package not in to_deb_packages.keys():
                 removed_deb_packages.append(package)
+                changelog["removed"]["deb"][package] = {"from": {"version": version}, "to": {"version": None}}
 
-        for package in to_deb_packages.keys():
+        for package, version in to_deb_packages.items():
             if package not in from_deb_packages.keys():
                 added_deb_packages.append(package)
+                changelog["added"]["deb"][package] = {"from": {"version": None}, "to": {"version": version}}
 
         for to_package, to_package_version in to_deb_packages.items():
             # only need to find diff for packages that are not new
@@ -152,7 +193,9 @@ def main(
                         "from": from_package_version,
                         "to": to_package_version,
                     }
-
+        changelog["summary"]["deb"] = {"added": added_deb_packages,
+                                       "removed": removed_deb_packages,
+                                       "diff": list(deb_package_diffs.keys())}
         click.echo("Deb packages added: {}".format(added_deb_packages))
         click.echo("Deb packages removed: {}".format(removed_deb_packages))
         click.echo("Deb packages changed: {}".format(list(deb_package_diffs.keys())))
@@ -175,6 +218,9 @@ def main(
                     package, from_to["from"], from_to["to"]
                 )
             )
+
+            changelog["diff"]["snap"][package] = {"from": from_to["from"], "to": from_to["to"]}
+
             click.echo()
 
     if deb_package_diffs or added_deb_packages:
@@ -208,9 +254,13 @@ def main(
                     ppas,
                 )
 
-                # get the most recent changelog entry
-                version_diff_changelog = lib.parse_changelog(
-                    package_changelog_file, to_version=to_source_package_version, count=1
+                # get the three most recent changelog entries
+                version_diff_changelog, cves_referenced, version_diff_changelogs = lib.parse_changelog(
+                    launchpad,
+                    package_changelog_file,
+                    to_version=to_source_package_version,
+                    count=3,
+                    highlight_cves=highlight_cves
                 )
 
                 click.echo(
@@ -218,11 +268,46 @@ def main(
                     "==========================================================="
                 )
                 click.echo(
-                    "{} version '{}' (source package {} version '{}') was added. Below is the most recent changelog entry".format(
+                    "{} version '{}' (source package {} version '{}') was added. Below are the three most recent changelog entries".format(
                         package, to_deb_packages[package], to_source_package_name, to_source_package_version
                     )
                 )
+                changelog["added"]["deb"][package] = {
+                    "from": {
+                        "source_package_name": None,
+                        "source_package_version": None,
+                        "version": None,
+                    },
+                    "to": {
+                        "source_package_name": to_source_package_name,
+                        "source_package_version": to_source_package_version,
+                        "version": to_deb_packages[package],
+                    },
+                    "notes": ["For a newly added package only the three most recent changelog entries are shown."],
+                    "cves": [],
+                    "changes": [],
+                }
                 click.echo()
+                if highlight_cves and cves_referenced:
+                    click.echo("CVEs referenced in changelog:")
+                    for cve_referenced in cves_referenced:
+                        cve_priority_color = None
+                        cve_priority_bold = False
+                        if cve_referenced['cve_priority'] == 'high' or cve_referenced['cve_priority'] == 'critical':
+                            cve_priority_color = 'red'
+                            cve_priority_bold = True
+                        elif cve_referenced['cve_priority'] == 'medium':
+                            cve_priority_color = 'yellow'
+                            cve_priority_bold = True
+                        click.echo('\t- {} ({} priority){}'.format(cve_referenced['cve'], click.style(cve_referenced['cve_priority'], fg=cve_priority_color, bold=cve_priority_bold),
+                                                                   ': {}'.format(cve_referenced[
+                                                                                     'cve_description'])
+                                                                   if highlight_cves_show_cve_description else ''
+                                                                   ))
+                        changelog["added"]["deb"][package]["cves"].append(cve_referenced)
+                    click.echo()
+                for version_diff_changelogs_entry in version_diff_changelogs:
+                    changelog["added"]["deb"][package]["changes"].append(version_diff_changelogs_entry)
                 click.echo(version_diff_changelog)
 
             for package, from_to in deb_package_diffs.items():
@@ -242,8 +327,13 @@ def main(
 
 
                 # get changelog just between the from and to version
-                version_diff_changelog = lib.parse_changelog(
-                    package_changelog_file, from_version=from_source_package_version, to_version=to_source_package_version, count=None
+                version_diff_changelog, cves_referenced, version_diff_changelogs = lib.parse_changelog(
+                    launchpad,
+                    package_changelog_file,
+                    from_version=from_source_package_version,
+                    to_version=to_source_package_version,
+                    count=None,
+                    highlight_cves=highlight_cves
                 )
 
                 click.echo(
@@ -259,8 +349,48 @@ def main(
                         to_source_package_version,
                     )
                 )
+                changelog["diff"]["deb"][package] = {
+                    "from": {
+                        "source_package_name": from_source_package_name,
+                        "source_package_version": from_source_package_version,
+                        "version": from_to["from"],
+                    },
+                    "to": {
+                        "source_package_name": to_source_package_name,
+                        "source_package_version": to_source_package_version,
+                        "version": from_to["to"],
+                    },
+                    "cves": [],
+                    "changes": [],
+                }
                 click.echo()
+                if highlight_cves and cves_referenced:
+                    click.echo("CVEs referenced in changelog:")
+                    for cve_referenced in cves_referenced:
+                        cve_priority_color = None
+                        cve_priority_bold = False
+                        if cve_referenced['cve_priority'] == 'high' or cve_referenced['cve_priority'] == 'critical':
+                            cve_priority_color = 'red'
+                            cve_priority_bold = True
+                        elif cve_referenced['cve_priority'] == 'medium':
+                            cve_priority_color = 'yellow'
+                            cve_priority_bold = True
+                        click.echo('\t- {} ({} priority){}'.format(cve_referenced['cve'], click.style(cve_referenced['cve_priority'], fg=cve_priority_color, bold=cve_priority_bold),
+                                                                   ': {}'.format(cve_referenced[
+                                                                                     'cve_description'])
+                                                                   if highlight_cves_show_cve_description else ''
+                                                                   ))
+                        changelog["diff"]["deb"][package]["cves"].append(cve_referenced)
+                    click.echo()
+                for version_diff_changelogs_entry in version_diff_changelogs:
+                    changelog["diff"]["deb"][package]["changes"].append(version_diff_changelogs_entry)
                 click.echo(version_diff_changelog)
+    if output_json:
+        with open(output_json, 'w') as ouput_json_file:
+            if output_json_pretty:
+                json.dump(changelog, ouput_json_file, indent=4)
+            else:
+                json.dump(changelog, ouput_json_file)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
feat: Add support for including CVE details from each changelog and outputting to JSON file

One of the main use cases for creating a changelog between manifests is to be able to track the CVEs addressed.

This commit adds the ability to highlight these CVEs using the new `--highlight-cves` flag.

One feature previously lacking was JSON output or an output that can be parsed in automation.

JSON was the obvious choice. Using JSON output `--output-json changelog.json` in combination with `--highlight-cves`
will add even more detail about all CVEs, example:

```
"cves": [
        {
            "cve": "CVE-2022-32221",
            "url": "https://ubuntu.com/security/CVE-2022-32221",
            "cve_description": " [POST following PUT confusion]",
            "cve_priority": "medium",
            "cve_public_date": "2022-10-26 07:00:00 UTC"
        },
        {
            "cve": "CVE-2022-35252",
            "url": "https://ubuntu.com/security/CVE-2022-35252",
            "cve_description": " When curl is used to retrieve and parse cookies from a HTTP(S) server, itaccepts cookies using control codes that when later are sent back to a HTTPserver might make the server return 400 responses. Effectively allowing a\"sister site\" to deny service to all siblings.",
            "cve_priority": "low",
            "cve_public_date": "2022-09-23 14:15:00 UTC"
        }
    ],
```
