### PR TITLE
feat: Add optional `--from-serial` and `--to-serial` arguments for more diff metadata

### DIFF
--- a/demo.sh
+++ b/demo.sh
@@ -25,6 +25,8 @@ ubuntu-cloud-image-changelog generate --from-manifest 20220420-ubuntu-22.04-serv
                                       --to-manifest 20221117-ubuntu-22.04-server-cloudimg-amd64.manifest \
                                       --from-series jammy \
                                       --to-series jammy \
+                                      --from-serial 20220420 \
+                                      --to-serial 20221117 \
                                       --image-architecture amd64 \
                                       --highlight-cves \
                                       --notes "Changelog diff for Ubuntu 22.04 jammy base cloud image from serial 20220420 to 20221117" \

--- a/schema.json
+++ b/schema.json
@@ -26,6 +26,14 @@
             "title": "To Series",
             "type": "string"
         },
+        "from_serial": {
+            "title": "From Serial",
+            "type": "string"
+        },
+        "to_serial": {
+            "title": "To Serial",
+            "type": "string"
+        },
         "from_manifest_filename": {
             "title": "From Manifest Filename",
             "type": "string"

--- a/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/cli.py
+++ b/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/cli.py
@@ -39,6 +39,8 @@ def cli(ctx):
 )
 @click.option("--from-series", help='the Ubuntu series eg. "20.04" or "focal"', required=True)
 @click.option("--to-series", help='the Ubuntu series eg. "20.04" or "focal"', required=True)
+@click.option("--from-serial", help='The Ubuntu cloud image serial (cat /etc/cloud/build.info)', required=False, default=None)
+@click.option("--to-serial", help='The Ubuntu cloud image serial (cat /etc/cloud/build.info)', required=False, default=None)
 @click.option(
     "--from-manifest",
     required=True,
@@ -110,6 +112,8 @@ def generate(
     lp_credentials_store: Optional[str],
     from_series: str,
     to_series: str,
+    from_serial: str,
+    to_serial: str,
     from_manifest: click.File,
     to_manifest: click.File,
     ppas: List[str],
@@ -154,6 +158,8 @@ def generate(
             notes=notes,
             from_series=from_series,
             to_series=to_series,
+            from_serial=from_serial,
+            to_serial=to_serial,
             from_manifest_filename=from_manifest.name,
             to_manifest_filename=to_manifest.name,
             summary=Summary(

--- a/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/models.py
+++ b/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/models.py
@@ -91,5 +91,7 @@ class ChangelogModel(BaseModel):
     notes: Optional[str] = None
     from_series: str
     to_series: str
+    from_serial: str = None
+    to_serial: str = None
     from_manifest_filename: str
     to_manifest_filename: str


### PR DESCRIPTION
This is intended to be used to help add more metadata to the image diff.

You can find an Ubuntu cloud image serial @ /etc/cloud/build.info

These are optional and will appear as 'null' in image diff report if not supplied.