### PR TITLE
fix: Use correct source package name and version in deb diff from details

### DIFF
--- a/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/cli.py
+++ b/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/cli.py
@@ -541,8 +541,8 @@ def generate(
                 )
                 diff_deb_package_from_version = FromVersion(
                     version=from_to["from"],
-                    source_package_name=to_source_package_name,
-                    source_package_version=to_source_package_version,
+                    source_package_name=from_source_package_name,
+                    source_package_version=from_source_package_version,
                 )
                 diff_deb_package = DebPackage(
                     name=package,


### PR DESCRIPTION
Incorrectly using `to` values for source package name and source package version.

Example

```
"name": "curl",
                "from_version": {
                    "source_package_name": "curl",
                    "source_package_version": "7.68.0-1ubuntu2.18",
                    "version": "7.68.0-1ubuntu2.16"
                },
                "to_version": {
                    "source_package_name": "curl",
                    "source_package_version": "7.68.0-1ubuntu2.18",
                    "version": "7.68.0-1ubuntu2.18"
                },
```

Should be

```
"name": "curl",
                "from_version": {
                    "source_package_name": "curl",
                    "source_package_version": "7.68.0-1ubuntu2.16",
                    "version": "7.68.0-1ubuntu2.16"
                },
                "to_version": {
                    "source_package_name": "curl",
                    "source_package_version": "7.68.0-1ubuntu2.18",
                    "version": "7.68.0-1ubuntu2.18"
                },
```