### PR TITLE
feat: Add support for pydantic 2+

### DIFF
--- a/ubuntu_cloud_image_changelog/setup.py
+++ b/ubuntu_cloud_image_changelog/setup.py
@@ -10,7 +10,7 @@ with open("README.rst") as readme_file:
 with open("HISTORY.rst") as history_file:
     history = history_file.read()
 
-requirements = ["Click>=7.0", "colorama", "launchpadlib", "pydantic", "python-debian"]
+requirements = ["Click>=7.0", "colorama", "launchpadlib", "pydantic>=2", "python-debian"]
 
 setup(
     author="Philip Roche",

--- a/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/cli.py
+++ b/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/cli.py
@@ -583,9 +583,9 @@ def generate(
     if output_json:
         with open(output_json, "w") as ouput_json_file:
             if output_json_pretty:
-                ouput_json_file.write(changelog.json(indent=4))
+                ouput_json_file.write(changelog.model_dump_json(indent=4))
             else:
-                ouput_json_file.write(changelog.json())
+                ouput_json_file.write(changelog.model_dump_json())
 
 
 def echo_changes(highlight_cves, version_changelog_change):
@@ -631,7 +631,7 @@ def echo_changes(highlight_cves, version_changelog_change):
 @cli.command()
 @click.pass_context
 def schema(ctx):
-    click.echo(ChangelogModel.schema_json(indent=4))
+    click.echo(ChangelogModel.model_json_schema(indent=4))
 
 
 if __name__ == "__main__":

--- a/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/models.py
+++ b/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/models.py
@@ -21,15 +21,15 @@ class Summary(BaseModel):
 
 
 class FromVersion(BaseModel):
-    source_package_name: Optional[str]
-    source_package_version: Optional[str]
-    version: str = None
+    source_package_name: Optional[str] = None
+    source_package_version: Optional[str] = None
+    version: Optional[str] = None
 
 
 class ToVersion(BaseModel):
-    source_package_name: Optional[str]
-    source_package_version: Optional[str]
-    version: str = None
+    source_package_name: Optional[str] = None
+    source_package_version: Optional[str] = None
+    version: Optional[str] = None
 
 
 class Cve(BaseModel):
@@ -59,7 +59,7 @@ class DebPackage(BaseModel):
     cves: Optional[List[Cve]] = []
     launchpad_bugs_fixed: Optional[List[int]] = []
     changes: Optional[List[Change]] = []
-    notes: Optional[str]
+    notes: Optional[str] = None
 
 
 class SnapPackage(BaseModel):


### PR DESCRIPTION
See https://docs.pydantic.dev/latest/migration/

If pydantic 2+ is used with current codebase then changelog will fail to build.