### PR TITLE
Improve changelog parsing to handle fips version strings

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: ubuntu-cloud-image-changelog
-version: '0.14.1'
+version: '0.15.0'
 base: core20
 summary: Helpful utility to generate package changelog between two cloud images
 description: |

--- a/ubuntu_cloud_image_changelog/HISTORY.rst
+++ b/ubuntu_cloud_image_changelog/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+0.15.0 (2024-01-23)
+-------------------
+
+* Improve changelog parsing to work with fips version strings
+
 0.14.0 (2023-07-04)
 -------------------
 

--- a/ubuntu_cloud_image_changelog/setup.cfg
+++ b/ubuntu_cloud_image_changelog/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.14.1
+current_version = 0.15.0
 commit = True
 tag = True
 

--- a/ubuntu_cloud_image_changelog/setup.py
+++ b/ubuntu_cloud_image_changelog/setup.py
@@ -41,6 +41,6 @@ setup(
     name="ubuntu-cloud-image-changelog",
     packages=find_packages(include=["ubuntu_cloud_image_changelog", "ubuntu_cloud_image_changelog.*"]),
     url="https://github.com/CanonicalLtd/ubuntu-cloud-image-changelog",
-    version="0.14.1",
+    version="0.15.0",
     zip_safe=False,
 )

--- a/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/__init__.py
+++ b/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Philip Roche"""
 __email__ = "phil.roche@canonical.com"
-__version__ = "0.14.1"
+__version__ = "0.15.0"

--- a/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/cli.py
+++ b/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/cli.py
@@ -361,7 +361,7 @@ def generate(
                     from_to["to"],
                     ppas,
                 )
-                package_changelog_file = lib.get_changelog(
+                to_package_changelog_file = lib.get_changelog(
                     launchpad,
                     ubuntu,
                     to_lp_series,
@@ -380,11 +380,20 @@ def generate(
                     if removed_deb_package.from_version.source_package_name == to_source_package_name:
                         removed_source_package_name = removed_deb_package.from_version.source_package_name
                         removed_source_package_version = removed_deb_package.from_version.source_package_version
+                        removed_source_package_changelog_file = lib.get_changelog(
+                            launchpad,
+                            ubuntu,
+                            from_lp_series,
+                            tmp_cache_directory,
+                            removed_source_package_name,
+                            removed_source_package_version,
+                            ppas
+                        )
                         version_added_changelogs = lib.parse_changelog(
                             launchpad,
-                            package_changelog_file,
-                            from_version=removed_source_package_version,
+                            to_changelog_filename=to_package_changelog_file,
                             to_version=to_source_package_version,
+                            from_changelog_filename=removed_source_package_changelog_file,
                             count=None,
                             highlight_cves=highlight_cves,
                         )
@@ -421,7 +430,7 @@ def generate(
                 if not version_added_changelogs:
                     version_added_changelogs = lib.parse_changelog(
                         launchpad,
-                        package_changelog_file,
+                        to_changelog_filename=to_package_changelog_file,
                         to_version=to_source_package_version,
                         count=3,
                         highlight_cves=highlight_cves,
@@ -496,7 +505,17 @@ def generate(
                     to_source_package_version,
                 ) = lib.get_source_package_details(ubuntu, launchpad, to_lp_arch_series, package, from_to["to"], ppas)
 
-                package_changelog_file = lib.get_changelog(
+                from_package_changelog_file = lib.get_changelog(
+                    launchpad,
+                    ubuntu,
+                    from_lp_series,
+                    tmp_cache_directory,
+                    from_source_package_name,
+                    from_source_package_version,
+                    ppas
+                )
+
+                to_package_changelog_file = lib.get_changelog(
                     launchpad,
                     ubuntu,
                     to_lp_series,
@@ -510,9 +529,9 @@ def generate(
 
                 version_diff_changelogs = lib.parse_changelog(
                     launchpad,
-                    package_changelog_file,
-                    from_version=from_source_package_version,
+                    to_changelog_filename=to_package_changelog_file,
                     to_version=to_source_package_version,
+                    from_changelog_filename=from_package_changelog_file,
                     count=None,
                     highlight_cves=highlight_cves,
                 )

--- a/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/cli.py
+++ b/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/cli.py
@@ -40,8 +40,12 @@ def cli(ctx):
 )
 @click.option("--from-series", help='the Ubuntu series eg. "20.04" or "focal"', required=True)
 @click.option("--to-series", help='the Ubuntu series eg. "20.04" or "focal"', required=True)
-@click.option("--from-serial", help='The Ubuntu cloud image serial (cat /etc/cloud/build.info)', required=False, default=None)
-@click.option("--to-serial", help='The Ubuntu cloud image serial (cat /etc/cloud/build.info)', required=False, default=None)
+@click.option(
+    "--from-serial", help="The Ubuntu cloud image serial (cat /etc/cloud/build.info)", required=False, default=None
+)
+@click.option(
+    "--to-serial", help="The Ubuntu cloud image serial (cat /etc/cloud/build.info)", required=False, default=None
+)
 @click.option(
     "--from-manifest",
     required=True,
@@ -196,7 +200,6 @@ def generate(
 
         # Are there any snap package diffs?
         if from_snap_packages or to_snap_packages:
-
             for package, version in from_snap_packages.items():
                 if package not in to_snap_packages.keys():
                     removed_snap_packages.append(package)
@@ -236,12 +239,14 @@ def generate(
 
         # Are there any deb package diffs?
         if from_deb_packages or to_deb_packages:
-
             for package, version in from_deb_packages.items():
                 if package not in to_deb_packages.keys():
                     removed_deb_packages.append(package)
                     # Get the source package name and source package version for the removed package
-                    (removed_source_package_name, removed_source_package_version,) = lib.get_source_package_details(
+                    (
+                        removed_source_package_name,
+                        removed_source_package_version,
+                    ) = lib.get_source_package_details(
                         ubuntu,
                         launchpad,
                         to_lp_arch_series,
@@ -291,7 +296,6 @@ def generate(
             click.echo("Deb packages changed: {}".format(list(deb_package_diffs.keys())))
 
         if snap_package_diffs or snap_package_added:
-
             click.echo(
                 "\n** Package version diffs for for changed snap packages "
                 "below. Full changelog for snap packages are not listed **\n"
@@ -343,7 +347,6 @@ def generate(
                 click.echo()
 
         if deb_package_diffs or deb_package_added:
-
             click.echo("\n** Changelogs for added and changed deb packages " "below: **\n")
 
             # for each of the deb package diffs and new packages download the
@@ -353,7 +356,10 @@ def generate(
                     "==========================================================="
                     "==========================================================="
                 )
-                (to_source_package_name, to_source_package_version,) = lib.get_source_package_details(
+                (
+                    to_source_package_name,
+                    to_source_package_version,
+                ) = lib.get_source_package_details(
                     ubuntu,
                     launchpad,
                     to_lp_arch_series,
@@ -387,7 +393,7 @@ def generate(
                             tmp_cache_directory,
                             removed_source_package_name,
                             removed_source_package_version,
-                            ppas
+                            ppas,
                         )
                         version_added_changelogs = lib.parse_changelog(
                             launchpad,
@@ -491,8 +497,10 @@ def generate(
                 changelog.added.deb.append(added_deb_package)
 
             for package, from_to in deb_package_diffs.items():
-
-                (from_source_package_name, from_source_package_version,) = lib.get_source_package_details(
+                (
+                    from_source_package_name,
+                    from_source_package_version,
+                ) = lib.get_source_package_details(
                     ubuntu,
                     launchpad,
                     from_lp_arch_series,
@@ -512,7 +520,7 @@ def generate(
                     tmp_cache_directory,
                     from_source_package_name,
                     from_source_package_version,
-                    ppas
+                    ppas,
                 )
 
                 to_package_changelog_file = lib.get_changelog(

--- a/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/lib.py
+++ b/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/lib.py
@@ -162,11 +162,12 @@ def parse_changelog(
         for changelog_block in parsed_changelog:
             if not changelog_block.changes():
                 continue
-            if changelog_block.version and \
-                Version(changelog_block.version.full_version) > \
-                Version(to_version):
-                logging.warning("Changelog block version {} is unexpectedly greater than to_version {}".format(
-                    changelog_block.version.full_version, to_version))
+            if changelog_block.version and Version(changelog_block.version.full_version) > Version(to_version):
+                logging.warning(
+                    "Changelog block version {} is unexpectedly greater than to_version {}".format(
+                        changelog_block.version.full_version, to_version
+                    )
+                )
 
             # Attempt to parse theCVEs referenced in the changelog entries
             cves = []
@@ -255,19 +256,19 @@ def get_parseable_changelog_diff(
     if not from_changelog_filename:
         return open(to_changelog_filename).read()
     try:
-        with open(from_changelog_filename, "r") as from_changelog_fileptr, \
-        open(to_changelog_filename, "r") as to_changelog_fileptr:
+        with open(from_changelog_filename, "r") as from_changelog_fileptr, open(
+            to_changelog_filename, "r"
+        ) as to_changelog_fileptr:
             changelog_diff_lines = []
             unified_diff = difflib.unified_diff(from_changelog_fileptr.readlines(), to_changelog_fileptr.readlines())
             for line in unified_diff:
-
                 # Skip diff headers
                 if line.startswith(("+++", "---", "@@")):
                     continue
 
                 if line.startswith("+"):
                     changelog_diff_lines += [line[1:]]
-            return ''.join(changelog_diff_lines)
+            return "".join(changelog_diff_lines)
     except Exception as ex:
         logging.exception(ex)
         raise ex


### PR DESCRIPTION
## Description

Version comparison between conventional changelog entries and
package versions that included "fips" in the version strings
does not work as expected. As a result some changelog entries
are ommitted when reporting changes between two different versions
of a package.
Current commit avoids comparing version strings and instead fetches
changelogs for both versions being compared and computes an unified
diff to determine changes from one version to the next.

## Testing

Verified regenerated changelogs for serials from 20230720 to 20230804 for Anthos Baremetal 1.9 candidate images. 
- 20230725 changelog had the CVE details that were missing in the original changelog.
- The rest of the changelogs didn't have any unexpected changes from the original changelogs.
- Also tested serials from 20230805 to 20230811 for Anthos Baremetal 1.11 candidate images to verify package removal and addition was also reported as per original changelogs. Ref: https://partnerissuetracker.corp.google.com/issues/290401193#comment9 and https://partnerissuetracker.corp.google.com/issues/294213013#comment4
