### PR TITLE
fix: Improve buggy changelog diff logic

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: ubuntu-cloud-image-changelog
-version: '0.15.0'
+version: '0.15.1'
 base: core20
 summary: Helpful utility to generate package changelog between two cloud images
 description: |

--- a/ubuntu_cloud_image_changelog/setup.cfg
+++ b/ubuntu_cloud_image_changelog/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.15.0
+current_version = 0.15.1
 commit = True
 tag = True
 

--- a/ubuntu_cloud_image_changelog/setup.py
+++ b/ubuntu_cloud_image_changelog/setup.py
@@ -41,6 +41,6 @@ setup(
     name="ubuntu-cloud-image-changelog",
     packages=find_packages(include=["ubuntu_cloud_image_changelog", "ubuntu_cloud_image_changelog.*"]),
     url="https://github.com/CanonicalLtd/ubuntu-cloud-image-changelog",
-    version="0.15.0",
+    version="0.15.1",
     zip_safe=False,
 )

--- a/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/__init__.py
+++ b/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Philip Roche"""
 __email__ = "phil.roche@canonical.com"
-__version__ = "0.15.0"
+__version__ = "0.15.1"


### PR DESCRIPTION
## Overview 

Currently, the tool determines changes from one package version to the another by computing a unified diff of the changelogs.  However, this logic fails when a few change-describing lines are moved from under an older version to the change block under a newer version. A unified diff between such versions omits the lines carried forward.  This commit introduces changes that improve this logic.  With this commit, when determining the changes from one package version to another, the tool now finds all version entries in the changelog that are present in the newer package changelog but absent from the older package changelog. The change block entries under all the determined versions are then processed.

## Testing

- [x] Verified original and regenerated image diffs for anthos-baremetal-1-11-devel serial 20231117 to 20240131
- [x] Verify that 20230725 changelog had the CVE details that were missing in the original changelog.
- [x] Test serials from 20230805 to 20230811 for Anthos Baremetal 1.11 candidate images to verify package removal and addition was also reported as per original changelogs. Ref: https://partnerissuetracker.corp.google.com/issues/290401193#comment9 and https://partnerissuetracker.corp.google.com/issues/294213013#comment4

**Note on changes discovered in 20230802-anthos-baremetal-1-11 candidate regenerated image diff:**

Package: runc
From version: `1.1.4-0ubuntu1~20.04.3` to version: `1.1.7-0ubuntu1~20.04.1`
Regenerated diff does not include LP bug #1993442 listed under `1.1.4-0ubuntu1` (the "from version")
```
runc (1.1.4-0ubuntu1) lunar; urgency=medium

  * New upstream release (LP: #1993442).
  * Refresh patches.

 -- Lucas Kanashiro <kanashiro@ubuntu.com>  Wed, 16 Nov 2022 11:59:36 -0300

```

Comments: This looks good to me. Included here for full disclosure about the behavior of changes under this PR.