### PR TITLE
fix: Use arch from package name when present.

### DIFF
--- a/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/lib.py
+++ b/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/lib.py
@@ -19,6 +19,13 @@ def get_source_package_details(ubuntu, launchpad, lp_arch_series, binary_package
     source_package_name = None
     source_package_version = None
     archive = ubuntu.main_archive
+
+    # Packages names might include an arch.
+    # If so, that arch trumps the series arch.
+    binary_package_name, _, binary_arch_name = binary_package_name.partition(":")
+    if binary_arch_name and lp_arch_series.architecture_tag != binary_arch_name:
+        lp_arch_series = lp_arch_series.distro_series.getDistroArchSeries(archtag=binary_arch_name)
+
     binaries = archive.getPublishedBinaries(
         exact_match=True,
         binary_name=binary_package_name,


### PR DESCRIPTION
It appears launchpad api doesn't handle the binary:arch format when querying for binaries. If such a package name is specified, trim the arch out of the name and switch to querying that arch if it doesn't match the global target architecture.

Testing:

https://cloud-images.ubuntu.com/mantic/current/mantic-server-cloudimg-armhf.manifest
against a more recent manifest
`Deb packages changed: ['bsdextrautils', 'bsdutils', 'eject', 'fdisk', '[libblkid1:armhf', 'libfdisk1:armhf', 'libmount1:armhf', 'libnss3:armhf', 'libsmartcols1:armhf', 'libuuid1:armhf', 'mount', 'util-linux', 'uuid-runtime']
`
changelog generated for packages including libblkid1:armhf which would previously throw an exception.