### PR TITLE
chore: bump release version to 15.3

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: ubuntu-cloud-image-changelog
-version: '0.15.2'
+version: '0.15.3'
 base: core20
 summary: Helpful utility to generate package changelog between two cloud images
 description: |

--- a/ubuntu_cloud_image_changelog/setup.cfg
+++ b/ubuntu_cloud_image_changelog/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.15.2
+current_version = 0.15.3
 commit = True
 tag = True
 

--- a/ubuntu_cloud_image_changelog/setup.py
+++ b/ubuntu_cloud_image_changelog/setup.py
@@ -41,6 +41,6 @@ setup(
     name="ubuntu-cloud-image-changelog",
     packages=find_packages(include=["ubuntu_cloud_image_changelog", "ubuntu_cloud_image_changelog.*"]),
     url="https://github.com/CanonicalLtd/ubuntu-cloud-image-changelog",
-    version="0.15.2",
+    version="0.15.3",
     zip_safe=False,
 )

--- a/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/__init__.py
+++ b/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Philip Roche"""
 __email__ = "phil.roche@canonical.com"
-__version__ = "0.15.2"
+__version__ = "0.15.3"


### PR DESCRIPTION
This version bump is to enable a new version in PyPI.