### PR TITLE
fix: Report appropriately when a package version downgrades

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: ubuntu-cloud-image-changelog
-version: '0.15.3'
+version: '0.15.4'
 base: core20
 summary: Helpful utility to generate package changelog between two cloud images
 description: |

--- a/ubuntu_cloud_image_changelog/setup.cfg
+++ b/ubuntu_cloud_image_changelog/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.15.3
+current_version = 0.15.4
 commit = True
 tag = True
 

--- a/ubuntu_cloud_image_changelog/setup.py
+++ b/ubuntu_cloud_image_changelog/setup.py
@@ -41,6 +41,6 @@ setup(
     name="ubuntu-cloud-image-changelog",
     packages=find_packages(include=["ubuntu_cloud_image_changelog", "ubuntu_cloud_image_changelog.*"]),
     url="https://github.com/CanonicalLtd/ubuntu-cloud-image-changelog",
-    version="0.15.3",
+    version="0.15.4",
     zip_safe=False,
 )

--- a/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/__init__.py
+++ b/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Philip Roche"""
 __email__ = "phil.roche@canonical.com"
-__version__ = "0.15.3"
+__version__ = "0.15.4"

--- a/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/models.py
+++ b/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/models.py
@@ -60,6 +60,7 @@ class DebPackage(BaseModel):
     launchpad_bugs_fixed: Optional[List[int]] = []
     changes: Optional[List[Change]] = []
     notes: Optional[str] = None
+    is_version_downgrade: bool
 
 
 class SnapPackage(BaseModel):


### PR DESCRIPTION
This commit fixes the case where the tool crashes if there's a version downgrade between input manifests.
A "is_version_downgrade" field has been added to the output JSON to indicate if a debian package diff represents a version downgrade.

Testing: Used attached manifests as inputs. They include a netplan version downgrade. The generated image diff is also attached.

[jammy-20241008-minimal-jammy-minimal-cloudimg-amd64-gke-1.27.manifest.download.txt](https://github.com/user-attachments/files/18151481/jammy-20241008-minimal-jammy-minimal-cloudimg-amd64-gke-1.27.manifest.download.txt)
[jammy-20241108.1-minimal-jammy-minimal-cloudimg-amd64-gke-1.27.manifest.download.txt](https://github.com/user-attachments/files/18151482/jammy-20241108.1-minimal-jammy-minimal-cloudimg-amd64-gke-1.27.manifest.download.txt)
[image_diff.json](https://github.com/user-attachments/files/18151480/image_diff.json)

stdout: https://pastebin.ubuntu.com/p/Rp2mM9q9F3/