### PR TITLE
Retry harder on network blips

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: ubuntu-cloud-image-changelog
-version: '0.15.5'
+version: '0.15.6'
 base: core20
 summary: Helpful utility to generate package changelog between two cloud images
 description: |

--- a/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/__init__.py
+++ b/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Philip Roche"""
 __email__ = "phil.roche@canonical.com"
-__version__ = "0.15.5"
+__version__ = "0.15.6"

--- a/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/lib.py
+++ b/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/lib.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import re
+import time
 import urllib.parse
 from functools import wraps
 from typing import List, Optional, Set
@@ -19,17 +20,14 @@ def retry(_func=None, *, num_attempts: int = 5):
     def retry_inner(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
-            count = num_attempts
-            success = False
-            return_value = None
-            while not success and count > 0:
-                count -= 1
+            last_exception = ValueError("num_attempts < 0")
+            for attempt in range(num_attempts):
                 try:
-                    return_value = func(*args, **kwargs)
-                    success = True
-                except Exception:
-                    continue
-            return return_value
+                    return func(*args, **kwargs)
+                except Exception as e:
+                    last_exception = e
+                time.sleep(attempt)
+            raise last_exception
 
         return wrapper
 

--- a/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/lib.py
+++ b/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/lib.py
@@ -37,6 +37,7 @@ def retry(_func=None, *, num_attempts: int = 5):
         return retry_inner(_func)
 
 
+@retry
 def get_source_package_details(ubuntu, launchpad, lp_arch_series, binary_package_name, binary_package_version, ppas):
     # find the published binary for this series, binary_package_name
     # and binary_package_version
@@ -289,6 +290,7 @@ def get_versions_from_changelog(changelog_filename: str) -> Set[str]:
         return {version.full_version for version in Changelog(from_changelog_file_ptr.read()).versions}
 
 
+@retry
 def get_changelog(
     launchpad,
     ubuntu,
@@ -328,17 +330,17 @@ def get_changelog(
 
     package_version_in_archive_changelog = False
     package_version_in_ppa_changelog = False
-    with open(cache_filename, "wb") as cache_file:
-        archive = ubuntu.main_archive
+    archive = ubuntu.main_archive
 
-        # Get the published sources for this exact version
-        sources = archive.getPublishedSources(
-            exact_match=True,
-            source_name=source_package_name,
-            distro_series=lp_series,
-            order_by_date=True,
-            version=source_package_version,
-        )
+    # Get the published sources for this exact version
+    sources = archive.getPublishedSources(
+        exact_match=True,
+        source_name=source_package_name,
+        distro_series=lp_series,
+        order_by_date=True,
+        version=source_package_version,
+    )
+    with open(cache_filename, "wb") as cache_file:
         if len(sources):
             archive_changelog_url = sources[0].changelogUrl()
 

--- a/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/tests/test_get_cve_details.py
+++ b/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/tests/test_get_cve_details.py
@@ -1,6 +1,8 @@
 import unittest.mock as mock
 from unittest.mock import call
 
+import pytest
+
 from ubuntu_cloud_image_changelog import lib
 
 
@@ -8,7 +10,9 @@ def test_get_cve_details_retry():
     fake_url = "https://git.launchpad.net/ubuntu-cve-tracker/plain/active/somecve"
     _mock_launchpad = mock.MagicMock()
     _mock_launchpad._browser.get.side_effect = mock.Mock(side_effect=Exception("Test"))
-    lib._get_cve_details("somecve", _mock_launchpad)
+    with mock.patch("time.sleep"):
+        with pytest.raises(Exception):
+            lib._get_cve_details("somecve", _mock_launchpad)
     calls = [call(fake_url), call(fake_url), call(fake_url), call(fake_url), call(fake_url)]
     _mock_launchpad._browser.get.assert_called()
     _mock_launchpad._browser.get.assert_has_calls(calls)

--- a/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/tests/test_lib.py
+++ b/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/tests/test_lib.py
@@ -1,0 +1,67 @@
+import tempfile
+import unittest.mock as mock
+from unittest.mock import call
+
+import pytest
+
+from ubuntu_cloud_image_changelog import lib
+
+
+def test_get_source_package_retry():
+    """Archive package queries should retry on server error"""
+    mock_launchpad = mock.MagicMock()
+    mock_ubuntu = mock_launchpad.distributions["ubuntu"]
+
+    mock_ubuntu.main_archive.getPublishedBinaries.side_effect = Exception
+    with mock.patch("time.sleep"):
+        with pytest.raises(Exception):
+            lib.get_source_package_details(
+                mock_ubuntu,
+                mock_launchpad,
+                "noble",
+                "sl",
+                "1.0",
+                [],
+            )
+    expected_calls = [
+        call(
+            exact_match=True,
+            binary_name="sl",
+            distro_arch_series="noble",
+            order_by_date=True,
+            version="1.0",
+        )
+    ] * 5
+    calls = mock_ubuntu.main_archive.getPublishedBinaries.mock_calls
+    assert calls == expected_calls
+
+
+def test_get_changelog_retry():
+    """Archive sources queries should retry on server error"""
+    mock_launchpad = mock.MagicMock()
+    mock_ubuntu = mock_launchpad.distributions["ubuntu"]
+    mock_ubuntu.main_archive.getPublishedSources.side_effect = Exception
+
+    with mock.patch("time.sleep"):
+        with tempfile.TemporaryDirectory() as cache_dir:
+            with pytest.raises(Exception):
+                lib.get_changelog(
+                    mock_launchpad,
+                    mock_ubuntu,
+                    "noble",
+                    cache_dir,
+                    "sl",
+                    "1.0",
+                    [],
+                )
+    expected_calls = [
+        call(
+            exact_match=True,
+            source_name="sl",
+            distro_series="noble",
+            order_by_date=True,
+            version="1.0",
+        )
+    ] * 5
+    calls = mock_ubuntu.main_archive.getPublishedSources.mock_calls
+    assert calls == expected_calls

--- a/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/tests/test_retry.py
+++ b/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/tests/test_retry.py
@@ -1,0 +1,36 @@
+import unittest.mock as mock
+
+import pytest
+
+from ubuntu_cloud_image_changelog import lib
+
+
+def test_retry_first_try():
+    """Retry only retry on failure."""
+    arg = object()
+    return_value = object()
+    fn = mock.MagicMock(side_effect=lambda _: return_value)
+
+    with mock.patch("time.sleep") as mock_sleep:
+        result = lib.retry(fn)(arg)
+
+    fn.assert_called_once_with(arg)
+    assert result is return_value
+    mock_sleep.assert_not_called()
+
+
+def test_retry_raises():
+    """Retry raises the last error after exhaustion."""
+
+    class MyError(Exception):
+        pass
+
+    arg = object()
+    fn = mock.MagicMock(side_effect=MyError)
+
+    with mock.patch("time.sleep") as mock_sleep:
+        with pytest.raises(MyError):
+            lib.retry(fn, num_attempts=3)(arg)
+
+    assert fn.mock_calls == [mock.call(arg)] * 3
+    assert mock_sleep.mock_calls == [mock.call(0), mock.call(1), mock.call(2)]


### PR DESCRIPTION
feat: add retry to archive getPublishedSources/Binaries()
Those API calls, like all launchpad calls, are subject to fail and

fix: rework retry decorator
Retry will now bubble the last exception, instead of silently eating it and carrying on.
Add sleep to avoid hammering the Launchpad API.
 