### PR TITLE
fix: make *_serial fields in ChangelogModel optional

### DIFF
--- a/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/models.py
+++ b/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/models.py
@@ -92,7 +92,7 @@ class ChangelogModel(BaseModel):
     notes: Optional[str] = None
     from_series: str
     to_series: str
-    from_serial: str = None
-    to_serial: str = None
+    from_serial: Optional[str] = None
+    to_serial: Optional[str] = None
     from_manifest_filename: str
     to_manifest_filename: str

--- a/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/tests/test_input_models.py
+++ b/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/tests/test_input_models.py
@@ -1,0 +1,76 @@
+import tempfile
+from unittest import mock
+from click.testing import CliRunner
+
+import pytest
+
+from ubuntu_cloud_image_changelog.cli import generate
+
+@pytest.fixture
+def dummy_manifests():
+    # Create two temp files with dummy manifest content
+    from_manifest = tempfile.NamedTemporaryFile(mode="wb", delete=False)
+    to_manifest = tempfile.NamedTemporaryFile(mode="wb", delete=False)
+
+    from_manifest.write(b"dummydeb\t1.0-0\n")
+    to_manifest.write(b"dummydeb\t1.0-0\n")
+
+    return from_manifest, to_manifest
+
+
+@pytest.mark.parametrize(
+    'from_series, to_series, from_serial, to_serial, ppas, image_architecture, exit_code',
+    [
+        ('noble', 'noble', '20250101', '20250202', [], 'amd64', 0),
+        ('noble', 'noble', None, '20250202', [], 'amd64', 0),
+        ('noble', 'noble', '20250101', None, [], 'amd64', 0),
+    ]
+)
+def test_generate_validate_inputs_and_run(
+    dummy_manifests, from_series, to_series, from_serial, to_serial, ppas,
+    image_architecture, exit_code
+):
+    # Dummy manifests from pytest fixture
+    from_manifest, to_manifest = dummy_manifests
+
+    with \
+        mock.patch("ubuntu_cloud_image_changelog.cli.launchpadagent.get_launchpad") as mock_get_launchpad, \
+        mock.patch(
+            "ubuntu_cloud_image_changelog.cli.lib.arch_independent_package_name",
+            return_value="dummy-package-name-no-arch"
+        ), \
+        mock.patch(
+            "ubuntu_cloud_image_changelog.cli.lib.get_source_package_details",
+            return_value=("srcpkg", "1.0-0")
+        ), \
+        mock.patch(
+            "ubuntu_cloud_image_changelog.cli.lib.get_changelog",
+            return_value="/tmp/changelog"
+        ), \
+        mock.patch(
+            "ubuntu_cloud_image_changelog.cli.lib.parse_changelog",
+            return_value=(False, [])
+        ), \
+        mock.patch("ubuntu_cloud_image_changelog.cli.click.echo"):
+
+        mock_launchpad = mock.Mock()
+        mock_ubuntu = mock.Mock()
+        mock_launchpad.distributions = {"ubuntu": mock_ubuntu}
+        mock_get_launchpad.return_value = mock_launchpad
+
+        # CliRunner allows invoking a click command for testing purposes
+        runner = CliRunner()
+        result = runner.invoke(
+            generate,
+            [
+                "--from-series", from_series,
+                "--to-series", to_series,
+                "--from-serial", from_serial,
+                "--to-serial", to_serial,
+                "--from-manifest", from_manifest.name,
+                "--to-manifest", to_manifest.name,
+                "--image-architecture", image_architecture,
+                *[f"--ppa={ppa}" for ppa in ppas],
+            ]
+        )
+        assert result.exit_code == exit_code


### PR DESCRIPTION
This PR fixes #24 
1. Makes the `from_serial` and `to_serial` fields optional in the Changelog model.
2. Adds a basic parameterized pytest test to confirm the call to the changelog generation without the *serial options does not fail

Testing:
Used jammy manifests from different serials and run the changelog generation as in the issue linked to confirm there is no error happening when `from_serial` and `to_serial` are not provided. Further, the manifest changelog logged successfully.