### PR TITLE
fix: set default author and date in case the changelog can't be parsed

### DIFF
--- a/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/lib.py
+++ b/ubuntu_cloud_image_changelog/ubuntu_cloud_image_changelog/lib.py
@@ -271,6 +271,9 @@ def get_changelog_diff(
         with open(to_changelog_filename, "r") as to_changelog_file_ptr:
             parsed_to_changelog = Changelog(to_changelog_file_ptr.read())
             for changelog_block in parsed_to_changelog:
+                if changelog_block._no_trailer == True:
+                    logging.warning(f"Changelog block with no trailer found; omitting from diff: {changelog_block}")
+                    continue
                 if changelog_block.version.full_version not in from_changelog_versions:
                     changelog_diff += [changelog_block]
                 if count and len(changelog_diff) == count:


### PR DESCRIPTION
This is meant to fix an error we've seen where very old changelogs (from the 1990s) (e.g. [gpm](https://changelogs.ubuntu.com/changelogs/pool/main/g/gpm/gpm_1.20.7-12/changelog)) were not formatted precisely as python-debian expects, causing changelog parsing with this tool to fail.

Omitting malformed blocks seems like a sane way to handle very old changelog formats that don't parse correctly.